### PR TITLE
Added methods for retrieving filename and modifying file extensions

### DIFF
--- a/src/Path.php
+++ b/src/Path.php
@@ -174,6 +174,132 @@ class Path
     }
 
     /**
+     * Returns the filename from a file path.
+     *
+     * @param string $path  The path string
+     *
+     * @return string Filename.
+     */
+    public static function getFilename($path)
+    {
+        if ('' === $path) {
+            return '';
+        }
+
+        return basename($path);
+	}
+
+    /**
+     * Returns the filename without the extension from a file path.
+     *
+     * @param string       $path      The path string
+     * @param string|null  $extension If specified, only that extension is cut off
+     *
+     * @return string Filename without extension.
+     */
+    public static function getFilenameWithoutExtension($path, $extension = null)
+    {
+        if ('' === $path) {
+            return '';
+        }
+
+        if (null !== $extension) {
+            return trim(basename($path, $extension), '.');
+        }
+
+        return pathinfo($path, PATHINFO_FILENAME);
+    }
+
+    /**
+     * Returns the extension from a file path.
+     *
+     * @param string $path           The path string
+     * @param bool   $forceLowerCase Forces the extension to be lower-case
+     *
+     * @return string Extension from a file path.
+     */
+    public static function getExtension($path, $forceLowerCase = false)
+    {
+        if ('' === $path) {
+            return '';
+        }
+
+        $ext = pathinfo($path, PATHINFO_EXTENSION);
+
+        if ($forceLowerCase) {
+            $ext = function_exists('mb_strtolower') ? mb_strtolower($ext) : strtolower($ext);
+        }
+
+        return $ext;
+    }
+
+    /**
+     * Returns whether the path has an extension.
+     *
+     * @param string            $path        The path string
+     * @param string|array|null $extension   If null or not provided, checks if an extension exists,
+     *                                       otherwise checks for the specified extension or array of extensions
+     * @param bool              $ignoreCase  Whether to ignore case-sensitivity
+     *
+     * @return bool true if the path has an (or the specified) extension, otherwise false
+     */
+    public static function hasExtension($path, $extension = null, $ignoreCase = false)
+    {
+        if ('' === $path) {
+            return false;
+        }
+
+        $ext = self::getExtension($path, $ignoreCase);
+
+        // Only check if path has any extension
+        if (null === $extension) {
+            return !empty($ext);
+        }
+
+        // Make an array of extensions
+        if (!is_array($extension)) {
+            $extension = array(trim($extension, '.'));
+        }
+
+        if ($ignoreCase) {
+            $strToLower = function_exists('mb_strtolower') ? 'mb_strtolower' : 'strtolower';
+            $extension = array_map($strToLower, $extension);
+        }
+
+        return in_array($ext, $extension);
+    }
+
+    /**
+     * Changes the extension of a path string.
+     *
+     * @param string $path      The path string with filename.ext to change
+     * @param string $extension New extension
+     *
+     * @return string The new path string.
+     */
+    public static function changeExtension($path, $extension)
+    {
+        if ('' === $path) {
+            return '';
+        }
+
+        $ext = self::getExtension($path);
+        $extension = trim($extension, '.');
+
+        // No extension for paths
+        if ('/' == substr($path, -1)) {
+            return $path;
+        }
+
+        // No extension in path
+        if (empty($ext)) {
+            return $path . ('.' == substr($path, -1) ? '' : '.') . $extension;
+        }
+
+        return substr($path, 0, -strlen($ext)).$extension;
+    }
+
+    /**
      * Returns whether a path is absolute.
      *
      * @param string $path A path string

--- a/src/Path.php
+++ b/src/Path.php
@@ -275,7 +275,7 @@ class Path
 
         // Make an array of extensions
         if (!is_array($extensions)) {
-            $extensions = array(ltrim($extensions, '.'));
+            $extensions = array($extensions);
         }
 
         foreach($extensions as $key => $extension) {

--- a/src/Path.php
+++ b/src/Path.php
@@ -238,11 +238,7 @@ class Path
         $extension = pathinfo($path, PATHINFO_EXTENSION);
 
         if ($forceLowerCase) {
-            if (function_exists('mb_strtolower')) {
-                $extension = mb_strtolower($extension, mb_detect_encoding($extension));
-            } else {
-                $extension = strtolower($extension);
-            }
+            $extension = self::toLower($extension);
         }
 
         return $extension;
@@ -284,11 +280,7 @@ class Path
 
         foreach($extensions as $key => $extension) {
             if ($ignoreCase) {
-                if (function_exists('mb_strtolower')) {
-                    $extension = mb_strtolower($extension, mb_detect_encoding($extension));
-                } else {
-                    $extension = strtolower($extension);
-                }
+                $extension = self::toLower($extension);
             }
 
             // remove leading '.' in extensions array
@@ -739,6 +731,21 @@ class Path
         }
 
         return array($root, $path);
+    }
+
+    /**
+     * Converts string to lower-case (multi-byte safe if mbstring is installed).
+     *
+     * @param string $str The string
+     * @return string Lower case string
+     */
+    private static function toLower($str)
+    {
+        if (function_exists('mb_strtolower')) {
+            return mb_strtolower($str, mb_detect_encoding($str));
+        }
+
+        return strtolower($str);
     }
 
     private function __construct()

--- a/src/Path.php
+++ b/src/Path.php
@@ -20,6 +20,7 @@ namespace Webmozart\PathUtil;
  *
  * @since  1.0
  * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Thomas Schulz <mail@king2500.net>
  */
 class Path
 {

--- a/tests/PathTest.php
+++ b/tests/PathTest.php
@@ -199,15 +199,22 @@ class PathTest extends \PHPUnit_Framework_TestCase
             array('/webmozart/puli/style.css.twig', null, 'style.css'),
             array('/webmozart/puli/style.css.', null, 'style.css'),
             array('/webmozart/puli/style.css', null, 'style'),
-            array('/webmozart/puli/style.css', null, 'style'),
+            array('/webmozart/puli/.style.css', null, '.style'),
             array('/webmozart/puli/', null, 'puli'),
             array('/webmozart/puli', null, 'puli'),
             array('/', null, ''),
             array('', null, ''),
 
             array('/webmozart/puli/style.css', 'css', 'style'),
+            array('/webmozart/puli/style.css', '.css', 'style'),
             array('/webmozart/puli/style.css', 'twig', 'style.css'),
+            array('/webmozart/puli/style.css', '.twig', 'style.css'),
             array('/webmozart/puli/style.css', '', 'style.css'),
+            array('/webmozart/puli/style.css.', '', 'style.css'),
+            array('/webmozart/puli/style.css.', '.', 'style.css'),
+            array('/webmozart/puli/style.css.', '.css', 'style.css'),
+            array('/webmozart/puli/.style.css', 'css', '.style'),
+            array('/webmozart/puli/.style.css', '.css', '.style'),
         );
     }
 
@@ -221,7 +228,7 @@ class PathTest extends \PHPUnit_Framework_TestCase
 
     public function provideGetExtensionTests()
     {
-        return array(
+        $tests = array(
             array('/webmozart/puli/style.css.twig', false, 'twig'),
             array('/webmozart/puli/style.css', false, 'css'),
             array('/webmozart/puli/style.css.', false, ''),
@@ -232,7 +239,15 @@ class PathTest extends \PHPUnit_Framework_TestCase
 
             array('/webmozart/puli/style.CSS', false, 'CSS'),
             array('/webmozart/puli/style.CSS', true, 'css'),
+            array('/webmozart/puli/style.ÄÖÜ', false, 'ÄÖÜ'),
         );
+
+        if (extension_loaded('mbstring')) {
+            // This can only be tested, when mbstring is installed
+            $tests[] = array('/webmozart/puli/style.ÄÖÜ', true, 'äöü');
+        }
+
+        return $tests;
     }
 
     /**
@@ -245,7 +260,7 @@ class PathTest extends \PHPUnit_Framework_TestCase
 
     public function provideHasExtensionTests()
     {
-        return array(
+        $tests = array(
             array(true, '/webmozart/puli/style.css.twig', null, false),
             array(true, '/webmozart/puli/style.css', null, false),
             array(false, '/webmozart/puli/style.css.', null, false),
@@ -257,6 +272,7 @@ class PathTest extends \PHPUnit_Framework_TestCase
             array(true, '/webmozart/puli/style.css.twig', 'twig', false),
             array(false, '/webmozart/puli/style.css.twig', 'css', false),
             array(true, '/webmozart/puli/style.css', 'css', false),
+            array(true, '/webmozart/puli/style.css', '.css', false),
             array(true, '/webmozart/puli/style.css.', '', false),
             array(false, '/webmozart/puli/', 'ext', false),
             array(false, '/webmozart/puli', 'ext', false),
@@ -267,11 +283,22 @@ class PathTest extends \PHPUnit_Framework_TestCase
             array(true, '/webmozart/puli/style.css', 'CSS', true),
             array(false, '/webmozart/puli/style.CSS', 'css', false),
             array(true, '/webmozart/puli/style.CSS', 'css', true),
+            array(true, '/webmozart/puli/style.ÄÖÜ', 'ÄÖÜ', false),
 
             array(true, '/webmozart/puli/style.css', array('ext', 'css'), false),
+            array(true, '/webmozart/puli/style.css', array('.ext', '.css'), false),
             array(true, '/webmozart/puli/style.css.', array('ext', ''), false),
             array(false, '/webmozart/puli/style.css', array('foo', 'bar', ''), false),
+            array(false, '/webmozart/puli/style.css', array('.foo', '.bar', ''), false),
         );
+
+        if (extension_loaded('mbstring')) {
+            // This can only be tested, when mbstring is installed
+            $tests[] = array(true, '/webmozart/puli/style.ÄÖÜ', 'äöü', true);
+            $tests[] = array(true, '/webmozart/puli/style.ÄÖÜ', array('äöü'), true);
+        }
+
+        return $tests;
     }
 
     /**
@@ -287,9 +314,12 @@ class PathTest extends \PHPUnit_Framework_TestCase
         return array(
             array('/webmozart/puli/style.css.twig', 'html', '/webmozart/puli/style.css.html'),
             array('/webmozart/puli/style.css', 'sass', '/webmozart/puli/style.sass'),
+            array('/webmozart/puli/style.css', '.sass', '/webmozart/puli/style.sass'),
             array('/webmozart/puli/style.css', '', '/webmozart/puli/style.'),
             array('/webmozart/puli/style.css.', 'twig', '/webmozart/puli/style.css.twig'),
             array('/webmozart/puli/style.css.', '', '/webmozart/puli/style.css.'),
+            array('/webmozart/puli/style.css', 'äöü', '/webmozart/puli/style.äöü'),
+            array('/webmozart/puli/style.äöü', 'css', '/webmozart/puli/style.css'),
             array('/webmozart/puli/', 'css', '/webmozart/puli/'),
             array('/webmozart/puli', 'css', '/webmozart/puli.css'),
             array('/', 'css', '/'),


### PR DESCRIPTION
Coming from the C#/.NET world, the approciate "Path" class has a few more useful methods. These are only partially available in native PHP, so I thought this would be a good point to extend and complete your Path class with these:

```php
getFilename($path)
getFilenameWithoutExtension($path, $extension = null)
getExtension($path, $forceLowerCase = false)
hasExtension($path, $extension = null, $ignoreCase = false)
changeExtension($path, $extension)
```

I'm open for any discussion or if you don't like it / deny it.