### PR TITLE
Added method for combining path strings

### DIFF
--- a/src/Path.php
+++ b/src/Path.php
@@ -657,7 +657,7 @@ class Path
             }
 
             // Make the base path shorter until it fits into path
-            while (true)  {
+            while (true) {
                 if ('.' === $basePath) {
                     // No more base paths
                     $basePath = '';
@@ -678,6 +678,57 @@ class Path
         }
 
         return $bpRoot.$basePath;
+    }
+
+    /**
+     * Combines two or more path strings.
+     *
+     * The result is a canonical path.
+     *
+     * @param array|string $paths,... Paths parts as parameters or array
+     *
+     * @return null|string The combined path
+     *
+     * @since 1.2
+     */
+    public static function combine($paths)
+    {
+        if (!is_array($paths)) {
+            $paths = func_get_args();
+        }
+
+        $finalPath = null;
+        $wasScheme = false;
+
+        foreach ($paths as $path) {
+            $path = (string) $path;
+
+            if ('' === $path) {
+                continue;
+            }
+
+            if (null === $finalPath) {
+                // For first part we keep slashes, like '/top', 'C:\' or 'phar://'
+                $finalPath = $path;
+                $wasScheme = (strpos($path, '://') !== false);
+                continue;
+            }
+
+            // Only add slash if previous part didn't end with '/' or '\'
+            if (!in_array(substr($finalPath, -1), array('/', '\\'))) {
+                $finalPath .= '/';
+            }
+
+            // If first part included a scheme like 'phar://' we allow current part to start with '/', otherwise trim
+            $finalPath .= $wasScheme ? $path : ltrim($path, '/');
+            $wasScheme = false;
+        }
+
+        if (null === $finalPath) {
+            return null;
+        }
+
+        return self::canonicalize($finalPath);
     }
 
     /**

--- a/tests/PathTest.php
+++ b/tests/PathTest.php
@@ -945,4 +945,112 @@ class PathTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertSame($result, Path::isBasePath($path, $ofPath));
     }
+
+    public function provideCombineTests()
+    {
+        $object = new ObjectConvertibleToString('object/path');
+
+        return array(
+            array(null, null, null),
+            array('/path/to/test', null, '/path/to/test'),
+            array('/path/to//test', null, '/path/to/test'),
+            array(null, '/path/to/test', '/path/to/test'),
+            array(null, '/path/to//test', '/path/to/test'),
+
+            array('/path/to/test', 'subdir', '/path/to/test/subdir'),
+            array('/path/to/test/', 'subdir', '/path/to/test/subdir'),
+            array('/path/to/test', '/subdir', '/path/to/test/subdir'),
+            array('/path/to/test/', '/subdir', '/path/to/test/subdir'),
+            array('/path/to/test', './subdir', '/path/to/test/subdir'),
+            array('/path/to/test/', './subdir', '/path/to/test/subdir'),
+            array('/path/to/test/', '../parentdir', '/path/to/parentdir'),
+            array('/path/to/test', '../parentdir', '/path/to/parentdir'),
+            array('path/to/test/', '/subdir', 'path/to/test/subdir'),
+            array('path/to/test', '/subdir', 'path/to/test/subdir'),
+            array('../path/to/test', '/subdir', '../path/to/test/subdir'),
+            array('path', '../../subdir', '../subdir'),
+            array('/path', '../../subdir', '/subdir'),
+            array('../path', '../../subdir', '../../subdir'),
+
+            array('/path/to/test', 123, '/path/to/test/123'),
+            array('/path/to/test', $object, '/path/to/test/object/path'),
+
+            array(array('/path/to/test', 'subdir'), null, '/path/to/test/subdir'),
+            array(array('/path/to/test', '/subdir'), null, '/path/to/test/subdir'),
+            array(array('/path/to/test/', 'subdir'), null, '/path/to/test/subdir'),
+            array(array('/path/to/test/', '/subdir'), null, '/path/to/test/subdir'),
+
+            array(array('/path'), null, '/path'),
+            array(array('/path', 'to', '/test'), null, '/path/to/test'),
+            array(array('/path', null, '/test'), null, '/path/test'),
+            array(array('path', 'to', 'test'), null, 'path/to/test'),
+            array(array(), null, null),
+
+            array('base/path', 'to/test', 'base/path/to/test'),
+
+            array('C:\\path\\to\\test', 'subdir', 'C:/path/to/test/subdir'),
+            array('C:\\path\\to\\test\\', 'subdir', 'C:/path/to/test/subdir'),
+            array('C:\\path\\to\\test', '/subdir', 'C:/path/to/test/subdir'),
+            array('C:\\path\\to\\test\\', '/subdir', 'C:/path/to/test/subdir'),
+
+            array('/', 'subdir', '/subdir'),
+            array('/', '/subdir', '/subdir'),
+            array('C:/', 'subdir', 'C:/subdir'),
+            array('C:/', '/subdir', 'C:/subdir'),
+            array('C:\\', 'subdir', 'C:/subdir'),
+            array('C:\\', '/subdir', 'C:/subdir'),
+            array('C:', 'subdir', 'C:/subdir'),
+            array('C:', '/subdir', 'C:/subdir'),
+
+            array('phar://', '/path/to/test', 'phar:///path/to/test'),
+            array('phar:///', '/path/to/test', 'phar:///path/to/test'),
+            array('phar:///path/to/test', 'subdir', 'phar:///path/to/test/subdir'),
+            array('phar:///path/to/test', 'subdir/', 'phar:///path/to/test/subdir'),
+            array('phar:///path/to/test', '/subdir', 'phar:///path/to/test/subdir'),
+            array('phar:///path/to/test/', 'subdir', 'phar:///path/to/test/subdir'),
+            array('phar:///path/to/test/', '/subdir', 'phar:///path/to/test/subdir'),
+
+            array('phar://', 'C:/path/to/test', 'phar://C:/path/to/test'),
+            array('phar://', 'C:\\path\\to\\test', 'phar://C:/path/to/test'),
+            array('phar://C:/path/to/test', 'subdir', 'phar://C:/path/to/test/subdir'),
+            array('phar://C:/path/to/test', 'subdir/', 'phar://C:/path/to/test/subdir'),
+            array('phar://C:/path/to/test', '/subdir', 'phar://C:/path/to/test/subdir'),
+            array('phar://C:/path/to/test/', 'subdir', 'phar://C:/path/to/test/subdir'),
+            array('phar://C:/path/to/test/', '/subdir', 'phar://C:/path/to/test/subdir'),
+            array('phar://C:', 'path/to/test', 'phar://C:/path/to/test'),
+            array('phar://C:', '/path/to/test', 'phar://C:/path/to/test'),
+            array('phar://C:/', 'path/to/test', 'phar://C:/path/to/test'),
+            array('phar://C:/', '/path/to/test', 'phar://C:/path/to/test'),
+        );
+    }
+
+    /**
+     * @dataProvider provideCombineTests
+     */
+    public function testCombine($path1, $path2, $result)
+    {
+        $this->assertSame($result, Path::combine($path1, $path2));
+    }
+
+    public function testCombineVarArgs()
+    {
+        $this->assertSame('/path', Path::combine('/path'));
+        $this->assertSame('/path/to', Path::combine('/path', 'to'));
+        $this->assertSame('/path/to/test', Path::combine('/path', 'to', '/test'));
+        $this->assertSame('/path/to/test/subdir', Path::combine('/path', 'to', '/test', 'subdir/'));
+    }
+}
+
+class ObjectConvertibleToString
+{
+    private $path;
+
+    public function __construct($path)
+    {
+        $this->path = $path;
+    }
+    public function __toString()
+    {
+        return $this->path;
+    }
 }


### PR DESCRIPTION
As mentioned in #3 the .NET `Path` class has a few helpful methods; one still missing is a `combine` method.

Developers often need to combine path strings or partial paths. In most cases the base path is variable (maybe from a config file or database), so you dont know if it has a trailing "/" at the end and how to correctly append the subdir you're targeting:

```php
$newPath = $basePath.'subdir'; // does $basePath include a '/' at the end?
```

The .NET `Path` class has a `Combine` method, similar to what I suggest and implemented here.

```php
$newPath = Path::combine($basePath, 'subdir'); // it doesn't matter if $basePath 
                                               // includes the '/' at the end
```
Result is:
`/some/base/subdir`

To properly support relative paths, the resulting path gets canonicalized:
```php
// $basePath = '/some/base/';
$newPath = Path::combine($basePath, '../other');
```
=> `/some/other`

Supported are variable arguments and paths as array:
```php
Path::combine('/path', 'to', 'dir');  // => /path/to/dir
$paths = array('/path', 'to', 'dir');
Path::combine($paths);  // => /path/to/dir
```
