### PR TITLE
Link API Docs directly to Path class doc in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ All contents of this package are licensed under the [MIT license].
 [The Community Contributors]: https://github.com/webmozart/path-util/graphs/contributors
 [Composer]: https://getcomposer.org
 [Documentation]: docs/usage.md
-[API Docs]: https://webmozart.github.io/path-util/api
+[API Docs]: https://webmozart.github.io/path-util/api/latest/class-Webmozart.PathUtil.Path.html
 [issue tracker]: https://github.com/webmozart/path-util/issues
 [Git repository]: https://github.com/webmozart/path-util
 [@webmozart]: https://twitter.com/webmozart


### PR DESCRIPTION
I suggest linking the API Docs directly to the `Path` class doc, since it's the only one as of now.

Easier to find for people, and the only useful API doc page.