### PR TITLE
New class Url as addition for a later Puli PR

### DIFF
--- a/src/Url.php
+++ b/src/Url.php
@@ -28,8 +28,17 @@ use Webmozart\Assert\Assert;
 final class Url
 {
     /**
-     * @param string $path
-     * @param string $basePath
+     * Turns an URL into a relative path.
+     *
+     * If the base path is not an absolute path or URL, an exception is thrown.
+     * If the Domain name of path and basepath does not match, an exception is thrown.
+     *
+     * The result is a canonical path. This class is using functionality of Path class
+     *
+     * @see Path
+     *
+     * @param string $path     An URL to make relative.
+     * @param string $basePath A base path or URL.
      *
      * @return string
      */
@@ -61,7 +70,7 @@ final class Url
      * returned.
      *
      * list ($root, $path) = Path::split("http://example.com/webmozart")
-     * // => array("http://example.com", "webmozart")
+     * // => array("http://example.com", "/webmozart")
      *
      * list ($root, $path) = Path::split("http://example.com")
      * // => array("http://example.com", "")

--- a/src/Url.php
+++ b/src/Url.php
@@ -12,7 +12,6 @@
 namespace Webmozart\PathUtil;
 
 use InvalidArgumentException;
-use RuntimeException;
 use Webmozart\Assert\Assert;
 
 /**
@@ -33,7 +32,7 @@ final class Url
      * If the base path is not an absolute path or URL, an exception is thrown.
      * If the Domain name of path and basepath does not match, an exception is thrown.
      *
-     * The result is a canonical path. This class is using functionality of Path class
+     * The result is a canonical path. This class is using functionality of Path class.
      *
      * @see Path
      *

--- a/src/Url.php
+++ b/src/Url.php
@@ -27,8 +27,77 @@ use Webmozart\Assert\Assert;
  */
 final class Url
 {
+    /**
+     * @param string $path
+     * @param string $basePath
+     *
+     * @return string
+     */
     public static function makeRelative($path, $basePath)
     {
-        return Path::makeRelative($path, $basePath);
+        Assert::string($path, 'The path must be a string. Got: %s');
+        Assert::string($basePath, 'The base path must be a string. Got: %s');
+
+        list($root, $relativePath) = self::split($path);
+        list($baseRoot, $relativeBasePath) = self::split($basePath);
+
+        $path = Path::makeRelative($relativePath, $relativeBasePath);
+
+        if ('' !== $root && '' !== $baseRoot && $root !== $baseRoot) {
+            throw new InvalidArgumentException(sprintf(
+                'Domain "%s" doesn\'t equal to base "%s".',
+                $root,
+                $baseRoot
+            ));
+        }
+
+        return $path;
+    }
+
+    /**
+     * Splits a part into its root directory and the remainder.
+     *
+     * If the path has no URL, an empty root directory will be
+     * returned.
+     *
+     * list ($root, $path) = Path::split("http://example.com/webmozart")
+     * // => array("http://example.com", "webmozart")
+     *
+     * list ($root, $path) = Path::split("http://example.com")
+     * // => array("http://example.com", "")
+     *
+     * @param string $path The URL to split.
+     *
+     * @return string[] An array with the domain and the remaining
+     *                  relative path.
+     */
+    private static function split($path)
+    {
+        if ('' === $path) {
+            return array('', '');
+        }
+
+        // Remember scheme as part of the root, if any
+        if (false !== ($pos = strpos($path, '://'))) {
+            $scheme = substr($path, 0, $pos + 3);
+            $path = substr($path, $pos + 3);
+
+            if (false !== ($pos = strpos($path, '/'))) {
+                $domain = substr($path, 0, $pos);
+                $path = substr($path, $pos);
+            } else {
+                // No path, only domain
+                $domain = $path;
+                $path = '';
+            }
+        } else {
+            $scheme = '';
+            $domain = '';
+        }
+
+        // At this point, we have $scheme, $domain and $path
+        $root = $scheme.$domain;
+
+        return array($root, $path);
     }
 }

--- a/src/Url.php
+++ b/src/Url.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the webmozart/path-util package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Webmozart\PathUtil;
+
+use InvalidArgumentException;
+use RuntimeException;
+use Webmozart\Assert\Assert;
+
+/**
+ * Contains utility methods for handling URL strings.
+ *
+ * The methods in this class are able to deal with URLs.
+ *
+ * @since  1.0
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Claudio Zizza <claudio@budgegeria.de>
+ */
+final class Url
+{
+    public static function makeRelative($path, $basePath)
+    {
+        return Path::makeRelative($path, $basePath);
+    }
+}

--- a/src/Url.php
+++ b/src/Url.php
@@ -19,7 +19,7 @@ use Webmozart\Assert\Assert;
  *
  * The methods in this class are able to deal with URLs.
  *
- * @since  1.0
+ * @since  2.3
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Claudio Zizza <claudio@budgegeria.de>
@@ -36,18 +36,18 @@ final class Url
      *
      * @see Path
      *
-     * @param string $path     An URL to make relative.
-     * @param string $basePath A base path or URL.
+     * @param string $url     An URL to make relative.
+     * @param string $baseUrl A base path or URL.
      *
      * @return string
      */
-    public static function makeRelative($path, $basePath)
+    public static function makeRelative($url, $baseUrl)
     {
-        Assert::string($path, 'The path must be a string. Got: %s');
-        Assert::string($basePath, 'The base path must be a string. Got: %s');
+        Assert::string($url, 'The path must be a string. Got: %s');
+        Assert::string($baseUrl, 'The base path must be a string. Got: %s');
 
-        list($root, $relativePath) = self::split($path);
-        list($baseRoot, $relativeBasePath) = self::split($basePath);
+        list($root, $relativePath) = self::split($url);
+        list($baseRoot, $relativeBasePath) = self::split($baseUrl);
 
         $path = Path::makeRelative($relativePath, $relativeBasePath);
 
@@ -74,29 +74,29 @@ final class Url
      * list ($root, $path) = Path::split("http://example.com")
      * // => array("http://example.com", "")
      *
-     * @param string $path The URL to split.
+     * @param string $url The URL to split.
      *
      * @return string[] An array with the domain and the remaining
      *                  relative path.
      */
-    private static function split($path)
+    private static function split($url)
     {
-        if ('' === $path) {
+        if ('' === $url) {
             return array('', '');
         }
 
         // Remember scheme as part of the root, if any
-        if (false !== ($pos = strpos($path, '://'))) {
-            $scheme = substr($path, 0, $pos + 3);
-            $path = substr($path, $pos + 3);
+        if (false !== ($pos = strpos($url, '://'))) {
+            $scheme = substr($url, 0, $pos + 3);
+            $url = substr($url, $pos + 3);
 
-            if (false !== ($pos = strpos($path, '/'))) {
-                $domain = substr($path, 0, $pos);
-                $path = substr($path, $pos);
+            if (false !== ($pos = strpos($url, '/'))) {
+                $domain = substr($url, 0, $pos);
+                $url = substr($url, $pos);
             } else {
                 // No path, only domain
-                $domain = $path;
-                $path = '';
+                $domain = $url;
+                $url = '';
             }
         } else {
             $scheme = '';
@@ -106,6 +106,6 @@ final class Url
         // At this point, we have $scheme, $domain and $path
         $root = $scheme.$domain;
 
-        return array($root, $path);
+        return array($root, $url);
     }
 }

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * This file is part of the webmozart/path-util package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Webmozart\PathUtil\Tests;
+
+use Webmozart\PathUtil\Url;
+
+/**
+ * @since  2.2
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Claudio Zizza <claudio@budgegeria.de>
+ */
+class UrlTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideMakeRelativeTests
+     */
+    public function testMakeRelative($absoluteUrl, $baseUrl, $relativePath)
+    {
+        // URL
+        $relative = Url::makeRelative($absoluteUrl, $baseUrl);
+        $this->assertSame($this->createUrl($relativePath), $this->createUrl($relative));
+
+        // path
+        $relative = Url::makeRelative($absoluteUrl, $baseUrl);
+        $this->assertSame($relativePath, $relative);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The path must be a string. Got: array
+     */
+    public function testMakeRelativeFailsIfInvalidPath()
+    {
+        Url::makeRelative(array(), 'http://example.com/webmozart/puli');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The base path must be a string. Got: array
+     */
+    public function testMakeRelativeFailsIfInvalidBasePath()
+    {
+        Url::makeRelative('http://example.com/webmozart/puli/css/style.css', array());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The absolute path "http://example.com/webmozart/puli/css/style.css" cannot be made relative to the relative path "webmozart/puli". You should provide an absolute base path instead.
+     */
+    public function testMakeRelativeFailsIfAbsolutePathAndBasePathNotAbsolute()
+    {
+        Url::makeRelative('http://example.com/webmozart/puli/css/style.css', 'webmozart/puli');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The absolute path "http://example.com/webmozart/puli/css/style.css" cannot be made relative to the relative path "". You should provide an absolute base path instead.
+     */
+    public function testMakeRelativeFailsIfAbsolutePathAndBasePathEmpty()
+    {
+        Url::makeRelative('http://example.com/webmozart/puli/css/style.css', '');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The base path must be a string. Got: NULL
+     */
+    public function testMakeRelativeFailsIfBasePathNull()
+    {
+        Url::makeRelative('http://example.com/webmozart/puli/css/style.css', null);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testMakeRelativeFailsIfDifferentRoot()
+    {
+        $this->markTestSkipped();
+        Url::makeRelative('http://example.com/webmozart/puli/css/style.css', 'http://example2.com/webmozart/puli');
+    }
+
+    public function provideMakeRelativeTests()
+    {
+        return array(
+
+            array('/webmozart/puli/css/style.css', '/webmozart/puli', 'css/style.css'),
+            array('/webmozart/css/style.css', '/webmozart/puli', '../css/style.css'),
+            array('/css/style.css', '/webmozart/puli', '../../css/style.css'),
+
+            // relative to root
+            array('/css/style.css', '/', 'css/style.css'),
+
+            // same sub directories in different base directories
+            array('/puli/css/style.css', '/webmozart/css', '../../puli/css/style.css'),
+
+            array('/webmozart/puli/./css/style.css', '/webmozart/puli', 'css/style.css'),
+            array('/webmozart/puli/../css/style.css', '/webmozart/puli', '../css/style.css'),
+            array('/webmozart/puli/.././css/style.css', '/webmozart/puli', '../css/style.css'),
+            array('/webmozart/puli/./../css/style.css', '/webmozart/puli', '../css/style.css'),
+            array('/webmozart/puli/../../css/style.css', '/webmozart/puli', '../../css/style.css'),
+            array('/webmozart/puli/css/style.css', '/webmozart/./puli', 'css/style.css'),
+            array('/webmozart/puli/css/style.css', '/webmozart/../puli', '../webmozart/puli/css/style.css'),
+            array('/webmozart/puli/css/style.css', '/webmozart/./../puli', '../webmozart/puli/css/style.css'),
+            array('/webmozart/puli/css/style.css', '/webmozart/.././puli', '../webmozart/puli/css/style.css'),
+            array('/webmozart/puli/css/style.css', '/webmozart/../../puli', '../webmozart/puli/css/style.css'),
+
+            // first argument shorter than second
+            array('/css', '/webmozart/puli', '../../css'),
+
+            // second argument shorter than first
+            array('/webmozart/puli', '/css', '../webmozart/puli'),
+
+            // already relative
+            array('css/style.css', '/webmozart/puli', 'css/style.css'),
+
+            // both relative
+            array('css/style.css', 'webmozart/puli', '../../css/style.css'),
+
+            // relative to empty
+            array('css/style.css', '', 'css/style.css'),
+        );
+    }
+
+    /**
+     * Based of the given path this function creates a absolute or relative URL
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    private function createUrl($path, $domain = 'http://example.com')
+    {
+        if (0 < strlen($path) || '/' === $path[0]) {
+            $path = $domain.$path;
+        }
+
+        return $path;
+    }
+}

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -14,7 +14,7 @@ namespace Webmozart\PathUtil\Tests;
 use Webmozart\PathUtil\Url;
 
 /**
- * @since  2.2
+ * @since  2.3
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Claudio Zizza <claudio@budgegeria.de>
@@ -25,9 +25,9 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      * @dataProvider provideMakeRelativeTests
      * @covers Webmozart\PathUtil\Url
      */
-    public function testMakeRelative($absoluteUrl, $baseUrl, $relativePath)
+    public function testMakeRelative($absolutePath, $basePath, $relativePath)
     {
-        $relative = Url::makeRelative($absoluteUrl, $baseUrl);
+        $relative = Url::makeRelative($absolutePath, $basePath);
         $this->assertSame($relativePath, $relative);
     }
 
@@ -35,9 +35,9 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      * @dataProvider provideMakeRelativeTests
      * @covers Webmozart\PathUtil\Url
      */
-    public function testMakeRelativeWithUrl($absoluteUrl, $baseUrl, $relativePath)
+    public function testMakeRelativeWithUrl($absolutePath, $basePath, $relativePath)
     {
-        $relative = Url::makeRelative($this->createUrl($absoluteUrl), $this->createUrl($baseUrl));
+        $relative = Url::makeRelative($this->createUrl($absolutePath), $this->createUrl($basePath));
         $this->assertSame($relativePath, $relative);
     }
 
@@ -45,11 +45,11 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      * @dataProvider provideMakeRelativeTests
      * @covers Webmozart\PathUtil\Url
      */
-    public function testMakeRelativeWithFullUrl($absoluteUrl, $baseUrl, $relativePath)
+    public function testMakeRelativeWithFullUrl($absolutePath, $basePath, $relativePath)
     {
         $url = 'ftp://user:password@example.com:8080';
 
-        $relative = Url::makeRelative($this->createUrl($absoluteUrl, $url), $this->createUrl($baseUrl, $url));
+        $relative = Url::makeRelative($this->createUrl($absolutePath, $url), $this->createUrl($basePath, $url));
         $this->assertSame($relativePath, $relative);
     }
 
@@ -58,7 +58,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      * @expectedExceptionMessage The path must be a string. Got: array
      * @covers Webmozart\PathUtil\Url
      */
-    public function testMakeRelativeFailsIfInvalidPath()
+    public function testMakeRelativeFailsIfInvalidUrl()
     {
         Url::makeRelative(array(), 'http://example.com/webmozart/puli');
     }
@@ -68,7 +68,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      * @expectedExceptionMessage The base path must be a string. Got: array
      * @covers Webmozart\PathUtil\Url
      */
-    public function testMakeRelativeFailsIfInvalidBasePath()
+    public function testMakeRelativeFailsIfInvalidBaseUrl()
     {
         Url::makeRelative('http://example.com/webmozart/puli/css/style.css', array());
     }
@@ -78,7 +78,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      * @expectedExceptionMessage The absolute path "/webmozart/puli/css/style.css" cannot be made relative to the relative path "webmozart/puli". You should provide an absolute base path instead.
      * @covers Webmozart\PathUtil\Url
      */
-    public function testMakeRelativeFailsIfAbsolutePathAndBasePathNotAbsolute()
+    public function testMakeRelativeFailsIfBaseUrlNoUrl()
     {
         Url::makeRelative('http://example.com/webmozart/puli/css/style.css', 'webmozart/puli');
     }
@@ -88,7 +88,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      * @expectedExceptionMessage The absolute path "/webmozart/puli/css/style.css" cannot be made relative to the relative path "". You should provide an absolute base path instead.
      * @covers Webmozart\PathUtil\Url
      */
-    public function testMakeRelativeFailsIfAbsolutePathAndBasePathEmpty()
+    public function testMakeRelativeFailsIfBaseUrlEmpty()
     {
         Url::makeRelative('http://example.com/webmozart/puli/css/style.css', '');
     }
@@ -98,7 +98,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      * @expectedExceptionMessage The base path must be a string. Got: NULL
      * @covers Webmozart\PathUtil\Url
      */
-    public function testMakeRelativeFailsIfBasePathNull()
+    public function testMakeRelativeFailsIfBaseUrlNull()
     {
         Url::makeRelative('http://example.com/webmozart/puli/css/style.css', null);
     }

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -26,12 +26,27 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function testMakeRelative($absoluteUrl, $baseUrl, $relativePath)
     {
-        // URL
         $relative = Url::makeRelative($absoluteUrl, $baseUrl);
-        $this->assertSame($this->createUrl($relativePath), $this->createUrl($relative));
+        $this->assertSame($relativePath, $relative);
+    }
 
-        // path
-        $relative = Url::makeRelative($absoluteUrl, $baseUrl);
+    /**
+     * @dataProvider provideMakeRelativeTests
+     */
+    public function testMakeRelativeWithUrl($absoluteUrl, $baseUrl, $relativePath)
+    {
+        $relative = Url::makeRelative($this->createUrl($absoluteUrl), $this->createUrl($baseUrl));
+        $this->assertSame($relativePath, $relative);
+    }
+
+    /**
+     * @dataProvider provideMakeRelativeTests
+     */
+    public function testMakeRelativeWithFullUrl($absoluteUrl, $baseUrl, $relativePath)
+    {
+        $url = 'ftp://user:password@example.com:8080';
+
+        $relative = Url::makeRelative($this->createUrl($absoluteUrl, $url), $this->createUrl($baseUrl, $url));
         $this->assertSame($relativePath, $relative);
     }
 
@@ -55,7 +70,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The absolute path "http://example.com/webmozart/puli/css/style.css" cannot be made relative to the relative path "webmozart/puli". You should provide an absolute base path instead.
+     * @expectedExceptionMessage The absolute path "/webmozart/puli/css/style.css" cannot be made relative to the relative path "webmozart/puli". You should provide an absolute base path instead.
      */
     public function testMakeRelativeFailsIfAbsolutePathAndBasePathNotAbsolute()
     {
@@ -64,7 +79,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The absolute path "http://example.com/webmozart/puli/css/style.css" cannot be made relative to the relative path "". You should provide an absolute base path instead.
+     * @expectedExceptionMessage The absolute path "/webmozart/puli/css/style.css" cannot be made relative to the relative path "". You should provide an absolute base path instead.
      */
     public function testMakeRelativeFailsIfAbsolutePathAndBasePathEmpty()
     {
@@ -82,10 +97,10 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Domain "http://example.com" doesn't equal to base "http://example2.com".
      */
-    public function testMakeRelativeFailsIfDifferentRoot()
+    public function testMakeRelativeFailsIfDifferentDomains()
     {
-        $this->markTestSkipped();
         Url::makeRelative('http://example.com/webmozart/puli/css/style.css', 'http://example2.com/webmozart/puli');
     }
 
@@ -140,7 +155,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      */
     private function createUrl($path, $domain = 'http://example.com')
     {
-        if (0 < strlen($path) || '/' === $path[0]) {
+        if (0 < strlen($path) && '/' === $path[0]) {
             $path = $domain.$path;
         }
 

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -23,6 +23,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider provideMakeRelativeTests
+     * @covers Url
      */
     public function testMakeRelative($absoluteUrl, $baseUrl, $relativePath)
     {
@@ -32,6 +33,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider provideMakeRelativeTests
+     * @covers Url
      */
     public function testMakeRelativeWithUrl($absoluteUrl, $baseUrl, $relativePath)
     {
@@ -41,6 +43,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider provideMakeRelativeTests
+     * @covers Url
      */
     public function testMakeRelativeWithFullUrl($absoluteUrl, $baseUrl, $relativePath)
     {
@@ -53,6 +56,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The path must be a string. Got: array
+     * @covers Url
      */
     public function testMakeRelativeFailsIfInvalidPath()
     {
@@ -62,6 +66,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The base path must be a string. Got: array
+     * @covers Url
      */
     public function testMakeRelativeFailsIfInvalidBasePath()
     {
@@ -71,6 +76,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The absolute path "/webmozart/puli/css/style.css" cannot be made relative to the relative path "webmozart/puli". You should provide an absolute base path instead.
+     * @covers Url
      */
     public function testMakeRelativeFailsIfAbsolutePathAndBasePathNotAbsolute()
     {
@@ -80,6 +86,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The absolute path "/webmozart/puli/css/style.css" cannot be made relative to the relative path "". You should provide an absolute base path instead.
+     * @covers Url
      */
     public function testMakeRelativeFailsIfAbsolutePathAndBasePathEmpty()
     {
@@ -89,6 +96,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The base path must be a string. Got: NULL
+     * @covers Url
      */
     public function testMakeRelativeFailsIfBasePathNull()
     {
@@ -98,6 +106,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Domain "http://example.com" doesn't equal to base "http://example2.com".
+     * @covers Url
      */
     public function testMakeRelativeFailsIfDifferentDomains()
     {
@@ -109,6 +118,8 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         return array(
 
             array('/webmozart/puli/css/style.css', '/webmozart/puli', 'css/style.css'),
+            array('/webmozart/puli/css/style.css?key=value&key2=value', '/webmozart/puli', 'css/style.css?key=value&key2=value'),
+            array('/webmozart/puli/css/style.css?key[]=value&key[]=value', '/webmozart/puli', 'css/style.css?key[]=value&key[]=value'),
             array('/webmozart/css/style.css', '/webmozart/puli', '../css/style.css'),
             array('/css/style.css', '/webmozart/puli', '../../css/style.css'),
 

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -158,7 +158,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Based of the given path this function creates a absolute or relative URL
+     * Based of the given path this function creates a absolute or relative URL.
      *
      * @param string $path
      *

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -23,7 +23,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider provideMakeRelativeTests
-     * @covers Url
+     * @covers Webmozart\PathUtil\Url
      */
     public function testMakeRelative($absoluteUrl, $baseUrl, $relativePath)
     {
@@ -33,7 +33,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider provideMakeRelativeTests
-     * @covers Url
+     * @covers Webmozart\PathUtil\Url
      */
     public function testMakeRelativeWithUrl($absoluteUrl, $baseUrl, $relativePath)
     {
@@ -43,7 +43,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider provideMakeRelativeTests
-     * @covers Url
+     * @covers Webmozart\PathUtil\Url
      */
     public function testMakeRelativeWithFullUrl($absoluteUrl, $baseUrl, $relativePath)
     {
@@ -56,7 +56,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The path must be a string. Got: array
-     * @covers Url
+     * @covers Webmozart\PathUtil\Url
      */
     public function testMakeRelativeFailsIfInvalidPath()
     {
@@ -66,7 +66,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The base path must be a string. Got: array
-     * @covers Url
+     * @covers Webmozart\PathUtil\Url
      */
     public function testMakeRelativeFailsIfInvalidBasePath()
     {
@@ -76,7 +76,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The absolute path "/webmozart/puli/css/style.css" cannot be made relative to the relative path "webmozart/puli". You should provide an absolute base path instead.
-     * @covers Url
+     * @covers Webmozart\PathUtil\Url
      */
     public function testMakeRelativeFailsIfAbsolutePathAndBasePathNotAbsolute()
     {
@@ -86,7 +86,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The absolute path "/webmozart/puli/css/style.css" cannot be made relative to the relative path "". You should provide an absolute base path instead.
-     * @covers Url
+     * @covers Webmozart\PathUtil\Url
      */
     public function testMakeRelativeFailsIfAbsolutePathAndBasePathEmpty()
     {
@@ -96,7 +96,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The base path must be a string. Got: NULL
-     * @covers Url
+     * @covers Webmozart\PathUtil\Url
      */
     public function testMakeRelativeFailsIfBasePathNull()
     {
@@ -106,7 +106,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Domain "http://example.com" doesn't equal to base "http://example2.com".
-     * @covers Url
+     * @covers Webmozart\PathUtil\Url
      */
     public function testMakeRelativeFailsIfDifferentDomains()
     {


### PR DESCRIPTION
As referenced in puli/issues#92 I'd like to introduce this PR for a later clean up and extending of puli/url-generator and later fixes of Scrutinizer Analysis (https://scrutinizer-ci.com/g/puli/url-generator/issues/master).

Reusing functionality of `Path::makeRelative` resulted in using this method directly in `Url`. I'm not sure if this is okay for you, but it seems like we actually need the same behaviour for Urls like in `Path::makeRelative`, but with Url and domain names as root.