### PR TITLE
Add cross-platform readLink method

### DIFF
--- a/src/Path.php
+++ b/src/Path.php
@@ -932,6 +932,45 @@ final class Path
     }
 
     /**
+     * Return the target of a link.
+     *
+     * @param string $path          A path string.
+     * @param boolean $finalTarget  Whether to recursively follow links
+     *                              until a final target is reached or not.
+     *
+     * @return string Return the resolved link.
+     *
+     * @since 2.4 Added method.
+     */
+    public static function readLink($path, $finalTarget = false)
+    {
+        Assert::fileExists($path, 'The link %s does not exist and cannot be read.');
+
+        if (!is_link($path)) {
+            return $path;
+        }
+
+        // On Windows, transitive links are resolved to the final target by
+        // readlink(). realpath(), however, returns the target link on Windows,
+        // but not on Unix.
+
+        // /link1 -> /link2 -> /file
+
+        // Windows: readlink(/link1) => /file
+        //          realpath(/link1) => /link2
+
+        // Unix:    readlink(/link1) => /link2
+        //          realpath(/link1) => /file
+
+        if ('\\' === DIRECTORY_SEPARATOR) {
+            // Windows
+            return $finalTarget ? readlink($path) : realpath($path);
+        }
+
+        return $finalTarget ? realpath($path) : readlink($path);
+    }
+
+    /**
      * Splits a part into its root directory and the remainder.
      *
      * If the path has no root directory, an empty root directory will be


### PR DESCRIPTION
For various places in puli/repository (especially FilesystemRepository and its tests), we need to resolve links. For the moment, we have a private method in FilesystemRepository. I propose to add it in path-util as it avoids code dupplication and it let other packages use this. I would use this to fix a part of https://github.com/puli/repository/pull/91.

I'm not sure about the method signature, don't hesitate to tell me what you think :) .