### PR TITLE
Using pathinfo since basename is depending on locale

### DIFF
--- a/src/Path.php
+++ b/src/Path.php
@@ -327,7 +327,7 @@ final class Path
 
         Assert::string($path, 'The path must be a string. Got: %s');
 
-        return basename($path);
+        return pathinfo($path, PATHINFO_BASENAME);
     }
 
     /**


### PR DESCRIPTION
From original issue: https://github.com/php-http/multipart-stream-builder/issues/16

> When i'm create request, with russian or UTF8 file name, prepareHeaders return invalid filename in headers.